### PR TITLE
Remove external dependencies and use internal modules

### DIFF
--- a/ini/config.py
+++ b/ini/config.py
@@ -1,50 +1,79 @@
+import configparser
 import os
-import re
 import sys
-from attrdict2 import AttrMap
-from configobj import ConfigObj
+from dataclasses import dataclass
+from typing import Optional
 
 
-class ConfigParser:
-    @staticmethod
-    def to_object(d):
-        """
-        Convert config object to custom object
+def _is_float(val: str):
+    try:
+        float(val)
+        return True
+    except ValueError:
+        return False
+    return False
 
-        :param ConfigObj d: config object
-        :return: custom object
-        :rtype: attrdict.AttrMap
-        """
-        top = AttrMap(sequence_type=list)
-        seq = tuple, list, set, frozenset
-        for i, j in d.items():
-            if isinstance(j, dict):
-                setattr(top, i, ConfigParser.to_object(j))
-            elif isinstance(j, seq):
-                typed = []
-                for sj in j:
-                    if isinstance(sj, dict):
-                        typed.append(ConfigParser.to_object(sj))
-                    else:
-                        typed.append(sj)
-                setattr(top, i, typed)
+
+def _is_bool(val: str) -> bool:
+    return val.upper() in ["TRUE", "FALSE"]
+
+
+def _get_bool(val: str) -> bool:
+    return val.upper() == "TRUE"
+
+
+class ConfigParserException(Exception):
+    pass
+
+
+@dataclass
+class Sections:
+    raw_sections: configparser.ConfigParser
+
+    def __post_init__(self):
+        for section_key, section_value in self.raw_sections.items():
+            setattr(self, section_key, SectionContent(section_value.items()))
+
+
+@dataclass
+class SectionContent:
+    raw_section_content: configparser.ConfigParser
+
+    def __post_init__(self):
+        for section_content_k, section_content_v in self.raw_section_content:
+            if _is_float(section_content_v):
+                setattr(self, section_content_k, float(section_content_v))
+            elif section_content_v.isnumeric():
+                setattr(self, section_content_k, int(section_content_v))
+            elif "," in section_content_v:
+                setattr(
+                    self,
+                    section_content_k,
+                    [_item.strip() for _item in section_content_v.split(",")],
+                )
+            elif _is_bool(section_content_v):
+                setattr(self, section_content_k, _get_bool(section_content_v))
             else:
-                if j in ['true', 'false']:
-                    j = j == 'true'
-                elif re.match(r'^[0-9]+[\\.]+[0-9]+$', j):
-                    j = float(j)
-                elif j.isnumeric():
-                    if '.' in j:
-                        j = float(j)
-                    else:
-                        j = int(j)
-                setattr(top, i, j)
-        return top
+                setattr(self, section_content_k, section_content_v)
+
+
+class ConfigParser(Sections):
+    """Main Config Parser class.
+
+    ATTENTION! python internal configparser module also has a class
+    with the same name. (configparser.ConfigParser).
+    Watch out for the shadowing.
+    """
+
+    def __init__(self, raw_config_parser: configparser.ConfigParser):
+        """Initialize raw config."""
+        Sections.__init__(self, raw_config_parser)
 
     @staticmethod
-    def load(path=None):
+    def load(path: Optional[str] = None) -> "ConfigParser":
         """
         Load configuration by given path or `CONFIG` environment.
+
         The environment variable is primary lookup.
 
         :param str or None path: the configuration path
@@ -52,23 +81,25 @@ class ConfigParser:
         :rtype: attrdict.AttrMap
         """
         if path is None:
-            if 'CONFIG' in os.environ:
-                path = os.environ['CONFIG']
+            if "CONFIG" in os.environ:
+                path = os.environ["CONFIG"]
             elif len(sys.argv) > 1:
                 path = sys.argv[1]
             else:
-                raise Exception('Configuration parameter must be set')
+                raise ConfigParserException("Configuration parameter must be set")
 
         if path is None or len(path.strip()) == 0:
-            raise Exception('Configuration path is missing')
+            raise ConfigParserException("Configuration path is missing")
 
         if not os.path.exists(path):
-            raise Exception(f'Configuration file does not exists "{path}"')
+            raise ConfigParserException(f'Configuration file does not exists "{path}"')
 
-        conf = ConfigObj(path)
+        config = configparser.ConfigParser()
+        config.read(path)
 
         # size of sections must be greater than one
-        if len(conf.sections) == 0:
-            raise Exception('There are no any sections')
+        if len(config.sections()) == 0:
+            raise ConfigParserException("There are no any sections")
 
-        return ConfigParser.to_object(conf)
+        config_dataclass = ConfigParser(config)
+        return config_dataclass

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,4 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
-    install_requires=[
-        'attrdict2==0.0.2',
-        'configobj==5.0.6',
-    ],
 )


### PR DESCRIPTION
Apologies for stepping up and making a few minor changes; it was just for fun. 

I liked the idea behind. Thus changed a few small stuff.

- Removed dependencies to external libraries.
- Added typehints for better handling of modern ides. (You can check with `mypy ini/`)
- Added explicit ConfigParserException instead of Exception because catching a generic Exception is not a good idea. A user of the library might want to do:

```py

try:
    config operations
    other operations
except ConfigParserException as e:
...
except DatabaseException as e:
...
except SomeotherException as e:
```

I haven't changed any tests as they are the source of truth here.
